### PR TITLE
Updated the GpgMe driver to send required passphrase field through to…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 
 # always keep .keep files around
 !.keep
+
+# do not store the PHPStorm files
+.idea*

--- a/src/PhpGpg/Driver/GnuPG/GpgMe.php
+++ b/src/PhpGpg/Driver/GnuPG/GpgMe.php
@@ -183,7 +183,7 @@ class GpgMe extends AbstractDriver implements DriverInterface
 
         if ($key instanceof Key) {
             foreach ($key->getSubKeys() as $subKey) {
-                $this->getResource()->adddecryptkey($subKey->getFingerprint());
+                $this->getResource()->adddecryptkey($subKey->getFingerprint(), $passphrase);
             }
 
             return true;


### PR DESCRIPTION
GnuPG requires addDecryptKey to have the signature (Resource, Fingerprint, Passphrase). It was failing to be add based on sending a Key to the method.
